### PR TITLE
Suppress QEMU warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: main.efi
 	$(CC) $(CFLAGS) $< -o $@
 
 qemu: main.efi OVMF.fd image/EFI/BOOT/BOOTX64.EFI
-	qemu-system-x86_64 -nographic -bios OVMF.fd -hda fat:image
+	qemu-system-x86_64 -nographic -bios OVMF.fd -drive file=fat:rw:image,media=disk,format=raw
 
 image/EFI/BOOT/BOOTX64.EFI:
 	mkdir -p image/EFI/BOOT


### PR DESCRIPTION
QEMU warns that image format was not specified:

    $ qemu-system-x86_64 -nographic -bios OVMF.fd -hda fat:rw:image
    WARNING: Image format was not specified for 'json:{"fat-type": 0, "dir": "image", "driver": "vvfat", "floppy": false, "rw": true}' and probing guessed raw.
             Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
             Specify the 'raw' format explicitly to remove the restrictions.

on QEMU version: 3.0.0

    $ qemu-system-x86_64 --version
    QEMU emulator version 3.0.0
    Copyright (c) 2003-2017 Fabrice Bellard and the QEMU Project developers
